### PR TITLE
Cache key needs to be unique for each entry

### DIFF
--- a/app/Listeners/ProcessImages.php
+++ b/app/Listeners/ProcessImages.php
@@ -22,7 +22,7 @@ class ProcessImages implements ShouldQueue
                 watermark: $event->entry->watermark,
                 lowres: $event->entry->lowres,
             ),
-            fn () => Cache::forget('processed_images'),
+            fn () => Cache::forget("{$event->entry->id()}-processed-images"),
         ])->dispatch();
     }
 

--- a/app/Providers/ComputedPropertiesProvider.php
+++ b/app/Providers/ComputedPropertiesProvider.php
@@ -25,7 +25,7 @@ class ComputedPropertiesProvider extends ServiceProvider
         });
 
         Collection::computed('private_galleries', 'processed_images', function ($entry, $value) {
-            return Cache::rememberForever('processed_images', function () use ($entry) {
+            return Cache::rememberForever("{$entry->id()}-processed-images", function () use ($entry) {
                 $images = $entry->get('assets');
 
                 if (empty($images)) {


### PR DESCRIPTION
This PR fixes an issue where the processed images cache was shared for all private galleries. Ooops.