### PR TITLE
Improved handling of zip URLs

### DIFF
--- a/app/Livewire/Gallery.php
+++ b/app/Livewire/Gallery.php
@@ -55,8 +55,16 @@ class Gallery extends Component
         return $this->entry->download;
     }
 
-    #[Computed]
-    public function zipUrl(): string
+    public function downloadZip(): void
+    {
+        if (! $this->downloadEnabled) {
+            return;
+        }
+
+        $this->redirect($this->zipUrl());
+    }
+
+    protected function zipUrl(): string
     {
         $assets = empty($this->selection)
             ? $this->assets->all()

--- a/resources/views/components/download-button.blade.php
+++ b/resources/views/components/download-button.blade.php
@@ -1,15 +1,18 @@
 @props([
+    'as' => 'a',
     'label' => __('Download'),
     'url',
 ])
 
-<a
-    href="{{ $url }}"
+<{{ $as }}
     {{ $attributes->twMerge('inline-flex items-center justify-center gap-1.5 p-1 text-[13px] font-medium bg-white rounded text-black hover:bg-gray-100') }}
-    download
+    @if($as === 'a')
+        href="{{ $url }}"
+        download
+    @endif
 >
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
         <path fill-rule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14Zm.75-10.25a.75.75 0 0 0-1.5 0v4.69L6.03 8.22a.75.75 0 0 0-1.06 1.06l2.5 2.5a.75.75 0 0 0 1.06 0l2.5-2.5a.75.75 0 1 0-1.06-1.06L8.75 9.44V4.75Z" clip-rule="evenodd" />
     </svg>
     {{ $label }}
-</a>
+</{{ $as }}>

--- a/resources/views/components/gallery-toolbar.blade.php
+++ b/resources/views/components/gallery-toolbar.blade.php
@@ -19,7 +19,8 @@
                 @endif
 
                 <x-download-button
-                    url="{{ $this->zipUrl }}"
+                    as="button"
+                    wire:click="downloadZip"
                     label="{{ trans_choice('Download :count file|Download :count files', $this->assetsCount, ['count' => $this->assetsCount]) }}"
                     class="w-full sm:w-auto text-white px-4 gap-1.5 py-1.5 text-sm {{ count($this->selection) ? 'bg-blue-600 hover:bg-blue-700' : 'bg-black hover:bg-gray-700' }}"
                 />


### PR DESCRIPTION
This PR improves the handling of zip URLs to avoid excessive creation of encrypted zip objects.

This starter kit relies on the [aerni/zipper](https://github.com/aerni/statamic-zipper) addon to create zips on the fly. Every time Zipper returns a URL, it also stores a unique and encrypted object in the storage folder based on the zip's content. This object is then decrypted to create the zip when the URL is visited.

So far, we've been returning the zip's URL as a computed property. The issue with this approach is that every time a user adds an asset to the selection, the computed property would re-render and return a new unique zip URL. This would cause Zipper to store a new encrypted object for every unique selection taken by the user.

To avoid this issue, we are introducing a new downloadZip() action that redirects to the zipUrl() whenever the user clicks the download button. This way, we are only storing the encrypted object when the user actually triggers the download.